### PR TITLE
change http in jobs.js to https

### DIFF
--- a/jobs/jobs.js
+++ b/jobs/jobs.js
@@ -116,7 +116,7 @@ function handlePagination(totalNumber, searchInputResult, searchInputOneResult) 
 function getJobsAPI (searchInputResult, searchInputOneResult) {
 	var apiId = 'f79154d7';
 	var apiKey = '2423d428da62311114e0eebc8ee7e7e8'
-	var jobsApiUrl = `http://api.adzuna.com/v1/api/jobs/us/search/${currentPage}?app_id=${apiId}&app_key=${apiKey}&results_per_page=${showApiPerPage}&what=${searchInputResult}&where=${searchInputOneResult}&content-type=application/json`;
+	var jobsApiUrl = `https://api.adzuna.com/v1/api/jobs/us/search/${currentPage}?app_id=${apiId}&app_key=${apiKey}&results_per_page=${showApiPerPage}&what=${searchInputResult}&where=${searchInputOneResult}&content-type=application/json`;
 
 	fetch(jobsApiUrl)
 		.then(response => response.json())


### PR DESCRIPTION
this should fix the "Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure resource '<URL>'. This request has been blocked; the content must be served over HTTPS." error on the deployed site